### PR TITLE
Update the container version.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,8 @@ ARG EXTENSIONS_PATH=/app/phabricator/src/extensions
 COPY differential ${EXTENSIONS_PATH}/differential
 COPY conduit ${EXTENSIONS_PATH}/conduit
 COPY auth ${EXTENSIONS_PATH}/auth
+# Update build_url in version.json
+COPY phabext.json /app
+COPY update_build_url.py /app
+RUN /app/update_build_url.py
 VOLUME ["/app"]

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,5 @@
 ---
+
 # These environment variables must be set in CircleCI UI
 #
 # DOCKERHUB_REPO - docker hub repo, format: <username>/<repo>
@@ -23,9 +24,8 @@ dependencies:
 
 compile:
   override:
-    # create version.json
-    - invoke version >> version.json
-    - cp version.json $CIRCLE_ARTIFACTS
+    - invoke version >> phabext.json
+    - cp phabext.json $CIRCLE_ARTIFACTS
 
     # build the image
     - invoke build

--- a/tasks.py
+++ b/tasks.py
@@ -13,11 +13,11 @@ DOCKER_IMAGE_NAME = os.getenv('DOCKERHUB_REPO', 'mozilla/phabext')
 def version(ctx):
     """Print version information in JSON format."""
     print(json.dumps({
-        'commit':
+        'phabext_commit':
         os.getenv('CIRCLE_SHA1', None),
-        'version':
+        'phabext_version':
         os.getenv('CIRCLE_SHA1', None),
-        'source':
+        'phabext_source':
         'https://github.com/%s/%s' % (
             os.getenv('CIRCLE_PROJECT_USERNAME', 'mozilla-conduit'),
             os.getenv('CIRCLE_PROJECT_REPONAME', 'phabricator-extensions')
@@ -42,6 +42,7 @@ def imageid(ctx):
         image_name=DOCKER_IMAGE_NAME,
         format='{{.Id}}'
     ))
+
 
 @task
 def build_test(ctx):

--- a/tasks.py
+++ b/tasks.py
@@ -19,7 +19,7 @@ def version(ctx):
         os.getenv('CIRCLE_SHA1', None),
         'phabext_source':
         'https://github.com/%s/%s' % (
-            os.getenv('CIRCLE_PROJECT_USERNAME', 'mozilla-conduit'),
+            os.getenv('CIRCLE_PROJECT_USERNAME', 'mozilla-services'),
             os.getenv('CIRCLE_PROJECT_REPONAME', 'phabricator-extensions')
         ),
         'build':

--- a/update_build_url.py
+++ b/update_build_url.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python2.7
+""" Update the version,json to contain phabext information"""
+import json
+import sys
+
+try:
+    with open('/app/mozphab.json', 'r') as f:
+        mozphab_circle_data = json.load(f)
+except IOError:
+    print "mozphab.json not found"
+    mozphab_circle_data = {}
+try:
+    with open('/app/phabext.json', 'r') as g:
+        phabext_circle_data = json.load(g)
+except IOError:
+    print "phabext.json not found"
+    phabext_circle_data = {}
+mozphab_circle_data.update(phabext_circle_data)
+
+try:
+    with open('/app/version.json', 'w') as f:
+        json.dump(mozphab_circle_data, f)
+except IOError:
+    print "Could not create version.json"
+    sys.exit()


### PR DESCRIPTION
  - when the new container is built, we weren't updating the included
version information which was causing deployments to fail. Test this
method, which *should* merge the existing mozphab version.json with the
new phabext data.

phabext.json needs to be copied to image