### PR TITLE
Ckolos/user version.json

### DIFF
--- a/update_build_url.py
+++ b/update_build_url.py
@@ -4,10 +4,10 @@ import json
 import sys
 
 try:
-    with open('/app/mozphab.json', 'r') as f:
+    with open('/app/version.json', 'r') as f:
         mozphab_circle_data = json.load(f)
 except IOError:
-    print "mozphab.json not found"
+    print "version.json not found"
     mozphab_circle_data = {}
 try:
     with open('/app/phabext.json', 'r') as g:
@@ -18,8 +18,10 @@ except IOError:
 mozphab_circle_data.update(phabext_circle_data)
 
 try:
-    with open('/app/version.json', 'w') as f:
+    with open('/app/version.json', 'r+') as f:
+        f.seek(0)
         json.dump(mozphab_circle_data, f)
+        f.close()
 except IOError:
     print "Could not create version.json"
     sys.exit()


### PR DESCRIPTION
requires https://github.com/mozilla-services/mozphab/pull/25 to be merged first

This changes the assumption that the base container's version information is stored in mozphab.json. I will remove the debugging code once I am sure circle is going to do the right thing.