### PR TITLE
Restructure bug validation and tests

### DIFF
--- a/differential/customfield/__tests__/DifferentialBugzillaIdCustomFieldTestCase.php
+++ b/differential/customfield/__tests__/DifferentialBugzillaIdCustomFieldTestCase.php
@@ -6,28 +6,22 @@
 final class DifferentialBugzillaBugIDCustomFieldTestCase
   extends PhabricatorTestCase {
 
-  public function testBugIdCommitMessageFieldValidation() {
-    $test = array(
-      'false' => array(null, '', '12.3', '1e3'),
-      'true' => array('123')
-    );
+  public function testBugIdCommitMessageFieldBasicValidation() {
+    $invalids = array(null, '', ' ', '12.3', '1e3');
 
     $field = new DifferentialBugzillaBugIDCommitMessageField();
-    foreach ($test as $success => $ids) {
-      foreach ($ids as $value) {
-        $caught = false;
-        try {
-          $result = $field->validateFieldValue($value);
-        } catch (DifferentialFieldValidationException $ex) {
-          $caught = $ex;
-        }
-        if ($success == 'false') {
-          $this->assertTrue(
-            ($caught instanceof DifferentialFieldValidationException));
-        } else {
-          $this->assertEqual($result, $value);
-        }
+    $field->setViewer(PhabricatorUser::getOmnipotentUser());
+
+    foreach ($invalids as $value) {
+      $caught = false;
+      try {
+        $result = $field->validateFieldValue($value);
+      } catch (DifferentialFieldValidationException $ex) {
+        $caught = $ex;
       }
+
+      $this->assertTrue(
+          ($caught instanceof DifferentialFieldValidationException));
     }
   }
 
@@ -36,7 +30,7 @@ final class DifferentialBugzillaBugIDCustomFieldTestCase
     $field->setValue('123');
     $this->assertEqual(
       $field->renderPropertyViewValue(array())->getHTMLContent(),
-      '<a href="https://bugzilla/123" rel="noreferrer">123</a>'
+      '<a href="'.PhabricatorEnv::getEnvConfig('bugzilla.url').'/123" rel="noreferrer">123</a>'
     );
   }
 


### PR DESCRIPTION
Restructured the validation of bug IDs, rewrote tests to only check for failures because we don't have a real BMO service we want to test against.

To test:
- [ ] Run tests
- [ ] Log in as a non-admin user, try to change the bug number of a revision to a bug that doesn't exist.  Should fail.
- [ ] Try to change the bug number to a revision that *does* exist, should work