### PR TITLE
Upgrade mozphab container tag to Nov 7 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozilla/mozphab:3a516fb9d4cd991064feb58867e56c0bb3e4c01e
+FROM mozilla/mozphab:8fc2a8449fc1254f948660e9507531732e99f1a4
 
 COPY extensions /app/moz-extensions
 


### PR DESCRIPTION
As part of the Nov 7 upgrade in https://github.com/mozilla-services/mozphab/pull/33