### PR TITLE
Minor fix to docker-compose.test.yml

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,6 +8,8 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile-test
+    entrypoint:
+      - /app/entrypoint.sh
     environment:
       - MYSQL_HOST=phabdb
       - MYSQL_PORT=3306


### PR DESCRIPTION
- dumb-init is now the default entrypoint in the parent container now so
override the entrypoint in the docker compose file to allow the local
container functions to work as expected (and more importantly not fail @
circle)

passes @ circle