### PR TITLE
Bug 1653708: Don't throw TypeError if ping doesn't have "main comment"

### DIFF
--- a/moz-extensions/src/email/model/EmailRevisionCommentPinged.php
+++ b/moz-extensions/src/email/model/EmailRevisionCommentPinged.php
@@ -14,10 +14,10 @@ class EmailRevisionCommentPinged implements PublicEmailBody {
   /**
    * @param EmailRecipient $recipient
    * @param string $transactionLink
-   * @param string $pingedMainComment
+   * @param string|null $pingedMainComment
    * @param EmailInlineComment[] $pingedInlineComments
    */
-  public function __construct(EmailRecipient $recipient, string $transactionLink, string $pingedMainComment, array $pingedInlineComments) {
+  public function __construct(EmailRecipient $recipient, string $transactionLink, ?string $pingedMainComment, array $pingedInlineComments) {
     $this->recipient = $recipient;
     $this->transactionLink = $transactionLink;
     $this->pingedMainComment = $pingedMainComment;


### PR DESCRIPTION
It's possible for a "ping" to be from an inline comment that doesn't have a corresponding main comment. Therefore, the "$mainComment" must be nullable.