### PR TITLE
Bug 1653709: Replace "(optional)" with "<type>|null" in PHPDocs

### DIFF
--- a/moz-extensions/src/email/adapter/PublicPing.php
+++ b/moz-extensions/src/email/adapter/PublicPing.php
@@ -4,7 +4,7 @@
 class PublicPing {
   /** @var PhabricatorUser */
   public $targetUser;
-  /** @var string (optional) */
+  /** @var string|null */
   public $mainComment;
   /** @var EmailInlineComment[] */
   public $inlineComments;

--- a/moz-extensions/src/email/adapter/PublicRevisionComments.php
+++ b/moz-extensions/src/email/adapter/PublicRevisionComments.php
@@ -2,7 +2,7 @@
 
 
 class PublicRevisionComments {
-  /** @var string (optional) */
+  /** @var string|null */
   public $mainComment;
   /** @var EmailInlineComment[] */
   public $inlineComments;

--- a/moz-extensions/src/email/model/EmailEndpointResponseCursor.php
+++ b/moz-extensions/src/email/model/EmailEndpointResponseCursor.php
@@ -4,12 +4,12 @@
 class EmailEndpointResponseCursor {
   /** @var int */
   public $limit;
-  /** @var string (optional) */
+  /** @var string|null */
   public $after;
 
   /**
    * @param int $limit
-   * @param string $after (optional)
+   * @param string|null $after
    */
   public function __construct(int $limit, ?string $after) {
     $this->limit = $limit;

--- a/moz-extensions/src/email/model/EmailReviewer.php
+++ b/moz-extensions/src/email/model/EmailReviewer.php
@@ -8,7 +8,7 @@ class EmailReviewer {
   public $isActionable;
   /** @var string either 'accepted', 'requested-changes' 'unreviewed' or 'blocking' */
   public $status;
-  /** @var EmailRecipient[] (optional) */
+  /** @var EmailRecipient[] */
   public $recipients;
 
   /**

--- a/moz-extensions/src/email/model/EmailRevision.php
+++ b/moz-extensions/src/email/model/EmailRevision.php
@@ -8,14 +8,14 @@ class EmailRevision {
   public $name;
   /** @var string */
   public $link;
-  /** @var EmailBug (optional) */
+  /** @var EmailBug|null */
   public $bug;
 
   /**
    * @param int $revisionId
    * @param string $name
    * @param string $link
-   * @param EmailBug $bug (optional)
+   * @param EmailBug|null $bug
    */
   public function __construct(int $revisionId, string $name, string $link, ?EmailBug $bug) {
     $this->revisionId = $revisionId;

--- a/moz-extensions/src/email/model/EmailRevisionAbandoned.php
+++ b/moz-extensions/src/email/model/EmailRevisionAbandoned.php
@@ -3,7 +3,7 @@
 
 class EmailRevisionAbandoned implements PublicEmailBody
 {
-  /** @var string (optional) */
+  /** @var string|null */
   public $mainComment;
   /** @var EmailInlineComment[] */
   public $inlineComments;
@@ -13,7 +13,7 @@ class EmailRevisionAbandoned implements PublicEmailBody
   public $reviewers;
 
   /**
-   * @param string $mainComment (optional)
+   * @param string|null $mainComment
    * @param EmailInlineComment[] $inlineComments
    * @param string $transactionLink
    * @param EmailRecipient[] $reviewers

--- a/moz-extensions/src/email/model/EmailRevisionAccepted.php
+++ b/moz-extensions/src/email/model/EmailRevisionAccepted.php
@@ -3,7 +3,7 @@
 
 class EmailRevisionAccepted implements PublicEmailBody
 {
-  /** @var string (optional) */
+  /** @var string|null */
   public $mainComment;
   /** @var EmailInlineComment[] */
   public $inlineComments;
@@ -15,17 +15,17 @@ class EmailRevisionAccepted implements PublicEmailBody
   public $isReadyToLand;
   /** @var EmailRecipient[] */
   public $reviewers;
-  /** @var EmailRecipient (optional) */
+  /** @var EmailRecipient|null */
   public $author;
 
   /**
-   * @param string $mainComment (optional)
+   * @param string|null $mainComment
    * @param EmailInlineComment[] $inlineComments
    * @param string $transactionLink
    * @param string $landoLink
    * @param bool $isReadyToLand
    * @param EmailRecipient[] $reviewers
-   * @param EmailRecipient $author (optional)
+   * @param EmailRecipient|null $author
    */
   public function __construct(?string $mainComment, array $inlineComments, string $transactionLink, string $landoLink, bool $isReadyToLand, array $reviewers, ?EmailRecipient $author) {
     $this->mainComment = $mainComment;

--- a/moz-extensions/src/email/model/EmailRevisionCommentPinged.php
+++ b/moz-extensions/src/email/model/EmailRevisionCommentPinged.php
@@ -6,7 +6,7 @@ class EmailRevisionCommentPinged implements PublicEmailBody {
   public $recipient;
   /** @var string */
   public $transactionLink;
-  /** @var string */
+  /** @var string|null */
   public $pingedMainComment;
   /** @var EmailInlineComment[] */
   public $pingedInlineComments;

--- a/moz-extensions/src/email/model/EmailRevisionCommented.php
+++ b/moz-extensions/src/email/model/EmailRevisionCommented.php
@@ -5,21 +5,21 @@ class EmailRevisionCommented implements PublicEmailBody
 {
   /** @var string */
   public $transactionLink;
-  /** @var string (optional) */
+  /** @var string|null */
   public $mainComment;
   /** @var EmailInlineComment[] */
   public $inlineComments;
   /** @var EmailRecipient[] */
   public $reviewers;
-  /** @var EmailRecipient (optional) */
+  /** @var EmailRecipient|null */
   public $author;
 
   /**
    * @param string $transactionLink
-   * @param string $mainComment (optional)
+   * @param string|null $mainComment
    * @param EmailInlineComment[] $inlineComments
    * @param EmailRecipient[] $reviewers
-   * @param EmailRecipient $author (optional)
+   * @param EmailRecipient|null $author
    */
   public function __construct(string $transactionLink, ?string $mainComment, array $inlineComments, array $reviewers, ?EmailRecipient $author)
   {

--- a/moz-extensions/src/email/model/EmailRevisionLanded.php
+++ b/moz-extensions/src/email/model/EmailRevisionLanded.php
@@ -3,7 +3,7 @@
 
 class EmailRevisionLanded implements PublicEmailBody
 {
-  /** @var string (optional) */
+  /** @var string|null */
   public $mainComment;
   /** @var EmailInlineComment[] */
   public $inlineComments;
@@ -11,15 +11,15 @@ class EmailRevisionLanded implements PublicEmailBody
   public $transactionLink;
   /** @var EmailRecipient[] */
   public $reviewers;
-  /** @var EmailRecipient (optional) */
+  /** @var EmailRecipient|null */
   public $author;
 
   /**
-   * @param string $mainComment (optional)
+   * @param string|null $mainComment
    * @param EmailInlineComment[] $inlineComments
    * @param string $transactionLink
    * @param EmailRecipient[] $reviewers
-   * @param EmailRecipient $author (optional)
+   * @param EmailRecipient|null $author
    */
   public function __construct(?string $mainComment, array $inlineComments, string $transactionLink, array $reviewers, ?EmailRecipient $author)
   {

--- a/moz-extensions/src/email/model/EmailRevisionReclaimed.php
+++ b/moz-extensions/src/email/model/EmailRevisionReclaimed.php
@@ -3,7 +3,7 @@
 
 class EmailRevisionReclaimed implements PublicEmailBody
 {
-  /** @var string (optional) */
+  /** @var string|null */
   public $mainComment;
   /** @var EmailInlineComment[] */
   public $inlineComments;
@@ -13,7 +13,7 @@ class EmailRevisionReclaimed implements PublicEmailBody
   public $reviewers;
 
   /**
-   * @param string $mainComment (optional)
+   * @param string|null $mainComment
    * @param EmailInlineComment[] $inlineComments
    * @param string $transactionLink
    * @param EmailRecipient[] $reviewers

--- a/moz-extensions/src/email/model/EmailRevisionRequestedChanges.php
+++ b/moz-extensions/src/email/model/EmailRevisionRequestedChanges.php
@@ -4,21 +4,21 @@
 class EmailRevisionRequestedChanges implements PublicEmailBody {
   /** @var string */
   public $transactionLink;
-  /** @var string (optional) */
+  /** @var string|null */
   public $mainComment;
   /** @var EmailInlineComment[] */
   public $inlineComments;
   /** @var EmailRecipient[] */
   public $reviewers;
-  /** @var EmailRecipient (optional) */
+  /** @var EmailRecipient|null */
   public $author;
 
   /**
    * @param string $transactionLink
-   * @param string $mainComment (optional)
+   * @param string|null $mainComment
    * @param EmailInlineComment[] $inlineComments
    * @param EmailRecipient[] $reviewers
-   * @param EmailRecipient $author (optional)
+   * @param EmailRecipient|null $author
    */
   public function __construct(string $transactionLink, ?string $mainComment, array $inlineComments, array $reviewers, ?EmailRecipient $author)
   {

--- a/moz-extensions/src/email/model/EmailRevisionRequestedReview.php
+++ b/moz-extensions/src/email/model/EmailRevisionRequestedReview.php
@@ -3,7 +3,7 @@
 
 class EmailRevisionRequestedReview implements PublicEmailBody
 {
-  /** @var string (optional) */
+  /** @var string|null */
   public $mainComment;
   /** @var EmailInlineComment[] */
   public $inlineComments;
@@ -13,7 +13,7 @@ class EmailRevisionRequestedReview implements PublicEmailBody
   public $reviewers;
 
   /**
-   * @param string $mainComment (optional)
+   * @param string|null $mainComment
    * @param EmailInlineComment[] $inlineComments
    * @param string $transactionLink
    * @param EmailReviewer[] $reviewers

--- a/moz-extensions/src/email/model/SecureEmailRevision.php
+++ b/moz-extensions/src/email/model/SecureEmailRevision.php
@@ -6,13 +6,13 @@ class SecureEmailRevision {
   public $revisionId;
   /** @var string */
   public $link;
-  /** @var SecureEmailBug (optional) */
+  /** @var SecureEmailBug|null */
   public $bug;
 
   /**
-   * @param int $revisionId
+   * @param string $revisionId
    * @param string $link
-   * @param SecureEmailBug $bug (optional)
+   * @param SecureEmailBug|null $bug
    */
   public function __construct(string $revisionId, string $link, ?SecureEmailBug $bug) {
     $this->revisionId = $revisionId;

--- a/moz-extensions/src/email/model/SecureEmailRevisionAccepted.php
+++ b/moz-extensions/src/email/model/SecureEmailRevisionAccepted.php
@@ -9,7 +9,7 @@ class SecureEmailRevisionAccepted implements SecureEmailBody
   public $isReadyToLand;
   /** @var EmailRecipient[] */
   public $reviewers;
-  /** @var EmailRecipient (optional) */
+  /** @var EmailRecipient|null */
   public $author;
   /** @var int */
   public $commentCount;
@@ -20,7 +20,7 @@ class SecureEmailRevisionAccepted implements SecureEmailBody
    * @param string $landoLink
    * @param bool $isReadyToLand
    * @param EmailRecipient[] $reviewers
-   * @param EmailRecipient $author (optional)
+   * @param EmailRecipient|null $author
    * @param int $commentCount
    * @param string $transactionLink
    */

--- a/moz-extensions/src/email/model/SecureEmailRevisionCommented.php
+++ b/moz-extensions/src/email/model/SecureEmailRevisionCommented.php
@@ -5,14 +5,14 @@ class SecureEmailRevisionCommented implements SecureEmailBody
 {
   /** @var EmailRecipient[] */
   public $reviewers;
-  /** @var EmailRecipient (optional) */
+  /** @var EmailRecipient|null */
   public $author;
   /** @var string */
   public $transactionLink;
 
   /**
    * @param EmailRecipient[] $reviewers
-   * @param EmailRecipient $author (optional)
+   * @param EmailRecipient|null $author
    * @param string $transactionLink
    */
   public function __construct(array $reviewers, ?EmailRecipient $author, string $transactionLink) {

--- a/moz-extensions/src/email/model/SecureEmailRevisionLanded.php
+++ b/moz-extensions/src/email/model/SecureEmailRevisionLanded.php
@@ -5,7 +5,7 @@ class SecureEmailRevisionLanded implements SecureEmailBody
 {
   /** @var EmailRecipient[] */
   public $reviewers;
-  /** @var EmailRecipient (optional) */
+  /** @var EmailRecipient|null */
   public $author;
   /** @var int */
   public $commentCount;
@@ -14,7 +14,7 @@ class SecureEmailRevisionLanded implements SecureEmailBody
 
   /**
    * @param EmailRecipient[] $reviewers
-   * @param EmailRecipient $author (optional)
+   * @param EmailRecipient|null $author
    * @param int $commentCount
    * @param string $transactionLink
    */

--- a/moz-extensions/src/email/model/SecureEmailRevisionMetadataEdited.php
+++ b/moz-extensions/src/email/model/SecureEmailRevisionMetadataEdited.php
@@ -8,7 +8,7 @@ class SecureEmailRevisionMetadataEdited implements SecureEmailBody, PublicEmailB
   public $isTitleChanged;
   /** @var bool */
   public $isBugChanged;
-  /** @var EmailRecipient (optional) */
+  /** @var EmailRecipient|null */
   public $author;
   /** @var EmailMetadataEditedReviewer[] */
   public $reviewers;
@@ -17,7 +17,7 @@ class SecureEmailRevisionMetadataEdited implements SecureEmailBody, PublicEmailB
    * @param bool $isReadyToLand
    * @param bool $isTitleChanged
    * @param bool $isBugChanged
-   * @param EmailRecipient $author (optional)
+   * @param EmailRecipient|null $author
    * @param EmailMetadataEditedReviewer[] $reviewers
    */
   public function __construct(bool $isReadyToLand, bool $isTitleChanged, bool $isBugChanged, ?EmailRecipient $author, array $reviewers) {

--- a/moz-extensions/src/email/model/SecureEmailRevisionRequestedChanges.php
+++ b/moz-extensions/src/email/model/SecureEmailRevisionRequestedChanges.php
@@ -7,7 +7,7 @@ class SecureEmailRevisionRequestedChanges implements SecureEmailBody
   public $transactionLink;
   /** @var EmailRecipient[] */
   public $reviewers;
-  /** @var EmailRecipient (optional) */
+  /** @var EmailRecipient|null */
   public $author;
   /** @var int */
   public $commentCount;
@@ -15,7 +15,7 @@ class SecureEmailRevisionRequestedChanges implements SecureEmailBody
   /**
    * @param string $transactionLink
    * @param EmailRecipient[] $reviewers
-   * @param EmailRecipient $author (optional)
+   * @param EmailRecipient|null $author
    * @param int $commentCount
    */
   public function __construct(string $transactionLink, array $reviewers, ?EmailRecipient $author, int $commentCount) {


### PR DESCRIPTION
"<type>|null" is better-supported by PHPDoc tooling.