### PR TITLE
Bug 1653719: "core:customField" should be "core:customfield" in EmailKind identification

### DIFF
--- a/moz-extensions/src/email/adapter/EventKind.php
+++ b/moz-extensions/src/email/adapter/EventKind.php
@@ -106,7 +106,7 @@ class EventKind {
       } else if (in_array($type, ['core:comment', 'differential:inline'])) {
         $includesComment = true;
         continue;
-      } else if (in_array($type, ['core:customField', 'differential.revision.title', 'differential.revision.reviewers'])) {
+      } else if (in_array($type, ['core:customfield', 'differential.revision.title', 'differential.revision.reviewers'])) {
         return new EventKind(self::$METADATA_EDIT, null);
       }
     }


### PR DESCRIPTION
In order to detect "bug changes" as transactions that we're interested in, we need to detect them. We've been
doing that by looking at the `transactionType` of the transaction, but the string we were comparing against
was incorrect.