### PR TITLE
Bug 1654120: Increase phabricator.test fastcgi buffer size

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -37,5 +37,6 @@ server {
     fastcgi_pass phabricator:9000;
     fastcgi_index index.php;
     fastcgi_param SCRIPT_FILENAME $document_root/$fastcgi_script_name;
+    fastcgi_buffer_size 8k;
   }
 }


### PR DESCRIPTION
In a niche situation where a large amount of output is created by Phabricator and a
specific format of output is requested by the client (e.g.: gzip/default encoding), nginx
will choke due to too much data.

According to Stack Overflow [1], this is resolved by increasing the buffer size. Some
trial and error demonstrated that just "fastcgi_buffer_size" needed to be bumped.