### PR TITLE
Bug 1719223 - Don't require 2FA in local-dev

### DIFF
--- a/moz-extensions/src/auth/provider/PhabricatorBMOAuthProvider.php
+++ b/moz-extensions/src/auth/provider/PhabricatorBMOAuthProvider.php
@@ -45,7 +45,7 @@ final class PhabricatorBMOAuthProvider
     list($account, $response) = parent::processLoginRequest($controller);
 
     // If mfa is disabled in Bugzilla, do not allow login
-    if (!$adapter->getAccountMFA()) {
+    if (PhabricatorEnv::getEnvConfig('bugzilla.require_mfa') && !$adapter->getAccountMFA()) {
       $bugzilla_url = PhabricatorEnv::getEnvConfig('bugzilla.url') . '/userprefs.cgi?tab=mfa';
       $error_content = phutil_safe_html(
           'Login using Bugzilla requires multi-factor authentication ' .


### PR DESCRIPTION
This was fallout from moving to standard OAuth2 authentication using the BMO OAuth2 provider instead of the old custom auth code. Just needed to add back in the bugzilla.require_mfa check. We already set this to false for dev environments so the bugs original issue will also be fixed.